### PR TITLE
Add ability to format on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Follow the GDScript style guide.
 ### Open in External Editor (`Ctrl + E`)
 *Bypasses the "Use External Editor" setting*  
 Opens the current file in your configured external editor (Rider/VS Code/etc.) without enabling `text_editor/external/use_external_editor` in Godot settings.
+
+### Toggle Auto Run on Save in Project Settings
+Automatically formats the file upon saving the file.
+

--- a/addons/simple_gdscript_formatter/plugin.gd
+++ b/addons/simple_gdscript_formatter/plugin.gd
@@ -8,7 +8,7 @@ const SETTING_PATH: String = "formatter/simple_gdscript_formatter/auto_run_on_sa
 
 var format_key: InputEventKey
 var open_external_key: InputEventKey
-var code_edit: CodeEdit
+
 
 func _enter_tree():
 	if not ProjectSettings.has_setting(SETTING_PATH):
@@ -57,7 +57,7 @@ func _exit_tree():
 func _on_format_code():
 	var current_editor := EditorInterface.get_script_editor().get_current_editor()
 	if current_editor and current_editor.is_class("ScriptTextEditor"):
-		code_edit = current_editor.get_base_editor() as CodeEdit
+		var code_edit := current_editor.get_base_editor() as CodeEdit
 		var code = code_edit.text
 		var formatter = preload("formatter.gd").new()
 		var formatted_code = formatter.format(code_edit)
@@ -129,10 +129,6 @@ func _save_current_script() -> void:
 	editor.get_resource_filesystem().scan()
 	text_ctrl.tag_saved_version()
 	editor.edit_script(script_res)
-
-	# Perform this here to make sure it doesn't tag a file as saved auto-format isn't enabled
-	code_edit.tag_saved_version()
-
 
 
 func _on_any_save(arg) -> void:

--- a/addons/simple_gdscript_formatter/plugin.gd
+++ b/addons/simple_gdscript_formatter/plugin.gd
@@ -44,7 +44,6 @@ func _enter_tree():
 	open_external_key.ctrl_pressed = true
 	InputMap.action_add_event(OPEN_EXTERNAL_ACTION, open_external_key)
 
-	self.connect("scene_saved", _on_any_save)
 	self.connect("resource_saved", _on_any_save)
 
 
@@ -53,7 +52,7 @@ func _exit_tree():
 	InputMap.erase_action(FORMAT_ACTION)
 	remove_tool_menu_item("Open In External Editor")
 	InputMap.erase_action(OPEN_EXTERNAL_ACTION)
-	self.disconnect("scene_saved", _on_any_save)
+
 	self.disconnect("resource_saved", _on_any_save)
 
 

--- a/project.godot
+++ b/project.godot
@@ -18,10 +18,6 @@ boot_splash/image="uid://cn78s1t4clrbr"
 
 gdscript/warnings/untyped_declaration=2
 
-[dotnet]
-
-project/assembly_name="simple_gdscript_formatter"
-
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/simple_gdscript_formatter/plugin.cfg")

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,14 @@ boot_splash/image="uid://cn78s1t4clrbr"
 
 gdscript/warnings/untyped_declaration=2
 
+[dotnet]
+
+project/assembly_name="simple_gdscript_formatter"
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/simple_gdscript_formatter/plugin.cfg")
+
+[formatter]
+
+simple_gdscript_formatter/auto_run_on_save=false


### PR DESCRIPTION
# Description
- Adding the ability to automatically format the file when saving the file. 
- Add Project Setting: Formatter -> Simple Gdscript Formatter -> Auto Run on Save
  - This will autosave your file after formatting it. The keybind does not save. 
![Godot_v4 5-beta1_mono_win64_YatAgTbrmi](https://github.com/user-attachments/assets/668b05ca-1116-43c2-bd67-85f173493c31)