### PR TITLE
Add ProjectSetting to toggle Open In External Editor feature

### DIFF
--- a/addons/simple_gdscript_formatter/plugin.gd
+++ b/addons/simple_gdscript_formatter/plugin.gd
@@ -92,5 +92,6 @@ func _shortcut_input(event: InputEvent) -> void:
 	#Open in External Editor- uses ProjectSettings to enable or disable feature.
 	if ProjectSettings.get_setting(OPEN_EXTERNAL_ACTION, true):
 		if Input.is_action_pressed(OPEN_EXTERNAL_ACTION):
-			_open_external()
-			get_tree().root.set_input_as_handled()
+			if event is InputEventKey and event.get_keycode_with_modifiers() == Key.KEY_E | KeyModifierMask.KEY_MASK_CTRL:
+        		_open_external()
+        		get_tree().root.set_input_as_handled()

--- a/addons/simple_gdscript_formatter/plugin.gd
+++ b/addons/simple_gdscript_formatter/plugin.gd
@@ -13,6 +13,11 @@ func _enter_tree():
 		InputMap.erase_action(FORMAT_ACTION)
 	InputMap.add_action(FORMAT_ACTION)
 
+	#Setting to enable/disable the open_in_external_editor feature
+	if not ProjectSettings.has_setting(OPEN_EXTERNAL_ACTION):
+		ProjectSettings.set_setting(OPEN_EXTERNAL_ACTION, true)
+		ProjectSettings.set_initial_value(OPEN_EXTERNAL_ACTION, true)
+
 	format_key = InputEventKey.new()
 	format_key.keycode = KEY_L
 	format_key.ctrl_pressed = true
@@ -80,9 +85,12 @@ func _open_external() -> void:
 
 
 func _shortcut_input(event: InputEvent) -> void:
+	#Format the script
 	if Input.is_action_pressed(FORMAT_ACTION):
 		_on_format_code()
 		get_tree().root.set_input_as_handled()
-	if Input.is_action_pressed(OPEN_EXTERNAL_ACTION):
-		_open_external()
-		get_tree().root.set_input_as_handled()
+	#Open in External Editor- uses ProjectSettings to enable or disable feature.
+	if ProjectSettings.get_setting(OPEN_EXTERNAL_ACTION, true):
+		if Input.is_action_pressed(OPEN_EXTERNAL_ACTION):
+			_open_external()
+			get_tree().root.set_input_as_handled()


### PR DESCRIPTION
adds ProjectSetting to toggle the 'Open in External Editor' feature
Defaults to 'true'.

I use this add-on a lot, and I like it, but it is very annoying to have to remove this feature from the code when I add it to other projects. Reason being- it overshadows a built-in keybind (Ctrl+Shift+E) for 'Evaluate Selection'.
Evaluate Selection lets you call basic functions, and it outputs a result- but each time I press it with this add-on, it just opens VSCode instead. Very annoying. With this PR, it can be toggled via a ProjectSetting.